### PR TITLE
HCK-9173: comment out inactive schema statement in script

### DIFF
--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -53,7 +53,7 @@ module.exports = (baseProvider, options, app) => {
 			functions,
 			procedures,
 			comment,
-			isActivated,
+			isActivated = true,
 		}) {
 			let database;
 			const schemaComment = assignTemplates(templates.comment, {

--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -53,6 +53,7 @@ module.exports = (baseProvider, options, app) => {
 			functions,
 			procedures,
 			comment,
+			isActivated,
 		}) {
 			let database;
 			const schemaComment = assignTemplates(templates.comment, {
@@ -86,9 +87,10 @@ module.exports = (baseProvider, options, app) => {
 			const userProcedures = procedures.map(procedure =>
 				assignTemplates(templates.createProcedure, setOrReplace(procedure)),
 			);
-			return [database, comment ? _.trimStart(schemaComment) : '', ...userFunctions, ...userProcedures]
+			const statement = [database, comment ? _.trimStart(schemaComment) : '', ...userFunctions, ...userProcedures]
 				.filter(Boolean)
 				.join('\n');
+			return commentIfDeactivated(statement, { isActivated });
 		},
 
 		createTable(tableData, isActivated) {
@@ -283,6 +285,7 @@ module.exports = (baseProvider, options, app) => {
 					? procedures.map(hydrateProcedure(containerData.name)).filter(filterProcedure)
 					: [],
 				comment: containerData.description,
+				isActivated: containerData.isActivated,
 			};
 		},
 

--- a/forward_engineering/helpers/commentDeactivatedHelper.js
+++ b/forward_engineering/helpers/commentDeactivatedHelper.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 const commentIfDeactivated = (statement, data, isPartOfLine) => {
 	if (data.isActivated === false) {
 		if (isPartOfLine) {

--- a/forward_engineering/helpers/commentDeactivatedHelper.js
+++ b/forward_engineering/helpers/commentDeactivatedHelper.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 
 const commentIfDeactivated = (statement, data, isPartOfLine) => {
-	if (_.has(data, 'isActivated') && !data.isActivated) {
+	if (data.isActivated === false) {
 		if (isPartOfLine) {
 			return '/* ' + statement + ' */';
 		} else if (statement.includes('\n')) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9173" title="HCK-9173" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9173</a>  Statements are still incorrectly present in DDL/Script tab after 'isActivated' is disabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

You have no Jira task for this PR? Describe your changes here...

...

## Technical details

You feel the need to provide technical explanations? You can do it here...

...