### PR TITLE
HCK-10211: fix checking for Nan for numeric type

### DIFF
--- a/forward_engineering/helpers/columnDefinitionHelper.js
+++ b/forward_engineering/helpers/columnDefinitionHelper.js
@@ -23,7 +23,7 @@ module.exports = app => {
 		}
 
 		if (['NUMBER', 'DECIMAL', 'NUMERIC'].includes(type)) {
-			if (!_.isNaN(columnDefinition.scale) && !_.isNaN(columnDefinition.precision)) {
+			if (!isNaN(columnDefinition.scale) && !isNaN(columnDefinition.precision)) {
 				resultType = `${type}(${Number(columnDefinition.precision)},${Number(columnDefinition.scale)})`;
 			}
 		}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10211" title="HCK-10211" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10211</a>  [FE][dbt][Redshift] 'nan,nan' is produced for datatypes where precision/scale left empty
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
